### PR TITLE
Weitere Platzhalter im Serienbrief (release)

### DIFF
--- a/Serienbriefe/Serienbrief Warnbrief Eltern Informationen.txt
+++ b/Serienbriefe/Serienbrief Warnbrief Eltern Informationen.txt
@@ -1,5 +1,0 @@
-Der Warnbrief wurde in enger Rücksprache mit dem MSB konzipiert. Folgende Vorgaben wurden bestätigt:
-- Ein dezidierter Abschluss muss bei einer Abschlussgefährdung nicht ausgesprochen werden.
-- es Unterschreibt immer die Klassenleitung
-- eine gesonderte Warnung auf die Note 6 gibt es nicht
-- es werden im 2. Halbjahr nur diejenigen Noten aufgelistet, welche abweichend vom ersten Halbjahr defizitär sind


### PR DESCRIPTION
Kleingeschriebene Anreden, wie. z.B. sehr geehrte Frau XY. Dies ist notwendig, wenn man Briefe mit Anrede an den Schüler / die Schülerin und die Eltern richten möchte. Hier sah es nicht schön aus, wenn die zweitgenannte Personengruppe nach dem Trennkomma großgeschrieben wurde.
Löschen einer überflüssigen, redundanten Datei.